### PR TITLE
fix: TypeError python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ A Python interpreter will be neccesary to run this module. Package is compatible
 
 The NumPy library will need to be installed, before using this package. We will be updating this package to include the NumPy dependency. See 'Built With' section for installation of NumPy.
 
+#### Fixe python3 error - 2020/02/13 (benbenIo)
+```shell
+raw_cells = raw_cell_string.split('Cell') # Divide raw string into raw cells.
+TypeError: a bytes-like object is required, not 'str'
+```
+
 ### Installing
 
 The RSSI package can be installed via PIP or by cloning this GitHub repo. Future releases will include a package installer for Linux.
@@ -47,6 +53,8 @@ OR
 
 ```
 git clone https://github.com/jvillagomez/rssi_module.git
+cd rssi_module
+pip install .
 ```
 ### Classes
 

--- a/rssi/__init__.py
+++ b/rssi/__init__.py
@@ -132,7 +132,13 @@ class RSSI_Scan(object):
     @staticmethod
     def getSignalLevel(raw_cell):
         signal = raw_cell.split('Signal level=')[1]
-        signal = int(signal.split(' ')[0])
+        # Need small fixe when running on pi (Debian): signal is not the same format Signal level=47/100.
+        try:
+            # Ubuntu
+            signal = int(signal.split(' ')[0])
+        except:
+            # Debian
+            signal = int(signal.split('/')[0])
         return signal
 
     # parseCell

--- a/rssi/__init__.py
+++ b/rssi/__init__.py
@@ -64,6 +64,8 @@ class RSSI_Scan(object):
         # Block all execution, until the scanning completes.
         scan_process.wait()
         # Returns all output in a dictionary for easy retrieval.
+        # FIXE: TypeError python3
+        raw_output = raw_output.decode('utf-8')
         return {'output':raw_output,'error':raw_error}
 
     # getSSID


### PR DESCRIPTION
### Quick fix of TypeError
Uncountered the follwowing error with **python 3.6.8**:
```
raw_cells = raw_cell_string.split('Cell') # Divide raw string into raw cells.
TypeError: a bytes-like object is required, not 'str'
```

Thank for this cool project ! If the project is still active, I can help working on managing error (like wrong interface (POPEN - Error), or so.

Regards